### PR TITLE
Changing the default path value in the example config file.

### DIFF
--- a/conf.json.example
+++ b/conf.json.example
@@ -1,9 +1,9 @@
 {
     "tania_persistence_engine": "sqlite",
     "demo_mode": true,
-    "upload_path_area": "/Users/user/Code/golang/src/github.com/Tanibox/tania-server/uploads/areas",
-    "upload_path_crop": "/Users/user/Code/golang/src/github.com/Tanibox/tania-server/uploads/crops",
-    "sqlite_path": "/Users/user/Code/golang/src/github.com/Tanibox/tania-server/db/sqlite/tania.db",
+    "upload_path_area": "uploads/areas",
+    "upload_path_crop": "uploads/crops",
+    "sqlite_path": "db/sqlite/ddl.db",
     "mysql_host": "127.0.0.1",
     "mysql_port": "3306",
     "mysql_dbname": "tania",


### PR DESCRIPTION
I think it will be better to use relative path as default value for `upload_path_area`,
`upload_path_crop`, and `sqlite_path`. So, if user don't customise
default values when copying `conf.json.example`to `conf.json`, the programme will run
and the user can still login with default username and password.